### PR TITLE
Add spike strike automaton and update aggregate

### DIFF
--- a/aggregate/carrier/state.go
+++ b/aggregate/carrier/state.go
@@ -20,9 +20,15 @@ var (
 
 type JetIDs []string
 
+type Health struct {
+	Max   int
+	Value int
+}
+
 type CombatState struct {
 	ID     string
 	Status status
+	Health Health
 	Jets   JetIDs
 }
 

--- a/aggregate/carrier/store.go
+++ b/aggregate/carrier/store.go
@@ -10,6 +10,7 @@ type Store interface {
 	// WARNING: action strictly used by AGGREGATOR ONLY
 	appendEvent(Event) error
 	GetEvents() map[string][]Event
+	GetEntityIDs() []string
 }
 
 func NewStore() Store {
@@ -42,4 +43,12 @@ func (i impl) appendEvent(e Event) error {
 func (i impl) GetEvents() map[string][]Event {
 	events := i.eventsSet // Shallow clone
 	return events
+}
+
+func (i impl) GetEntityIDs() []string {
+	ids := []string{}
+	for key := range i.eventsSet {
+		ids = append(ids, key)
+	}
+	return ids
 }

--- a/aggregate/knight/store.go
+++ b/aggregate/knight/store.go
@@ -3,22 +3,24 @@ package knight
 import "github.com/R-jim/Momentum/aggregate/common"
 
 type impl struct {
-	events map[string][]Event
+	eventsSet map[string][]Event
 }
 type Store interface {
 	getEventsByID(id string) ([]Event, error)
 	// WARNING: action strictly used by AGGREGATOR ONLY
 	appendEvent(Event) error
+	GetEvents() map[string][]Event
+	GetEntityIDs() []string
 }
 
 func NewStore() Store {
 	return impl{
-		events: make(map[string][]Event),
+		eventsSet: make(map[string][]Event),
 	}
 }
 
 func (i impl) getEventsByID(id string) ([]Event, error) {
-	return i.events[id], nil
+	return i.eventsSet[id], nil
 }
 
 // WARNING: action strictly used by AGGREGATOR ONLY
@@ -27,12 +29,25 @@ func (i impl) appendEvent(e Event) error {
 		return common.ErrEventNotValid
 	}
 
-	events := i.events[e.ID]
+	events := i.eventsSet[e.ID]
 	if events == nil {
 		events = []Event{}
 	}
 
-	i.events[e.ID] = append(events, e)
+	i.eventsSet[e.ID] = append(events, e)
 
 	return nil
+}
+
+func (i impl) GetEvents() map[string][]Event {
+	events := i.eventsSet // Shallow clone
+	return events
+}
+
+func (i impl) GetEntityIDs() []string {
+	ids := []string{}
+	for key := range i.eventsSet {
+		ids = append(ids, key)
+	}
+	return ids
 }

--- a/aggregate/spike/aggregator.go
+++ b/aggregate/spike/aggregator.go
@@ -48,6 +48,21 @@ func (i aggregateImpl) aggregate(event Event) error {
 		if newState.ID == "" {
 			return common.ErrAggregateFail
 		}
+	case DamageEffect:
+		currentState := toState(events)
+		if currentState.Health.Value <= 0 {
+			return common.ErrAggregateFail
+		}
+	case StrikeEffect:
+		currentState := toState(events)
+		if currentState.Health.Value <= 0 {
+			return common.ErrAggregateFail
+		}
+	case MoveEffect:
+		currentState := toState(events)
+		if currentState.Health.Value <= 0 {
+			return common.ErrAggregateFail
+		}
 
 	default:
 		return common.ErrEffectNotSupported

--- a/aggregate/spike/events.go
+++ b/aggregate/spike/events.go
@@ -48,10 +48,11 @@ func NewDamageEvent(id string, damage int) Event {
 	}
 }
 
-func NewStrikeEvent(id string) Event {
+func NewStrikeEvent(id string, targetID string) Event {
 	return Event{
 		ID:     id,
 		Effect: StrikeEffect,
+		Data:   targetID,
 	}
 }
 

--- a/automaton/spike.go
+++ b/automaton/spike.go
@@ -1,8 +1,104 @@
 package automaton
 
+import (
+	"github.com/R-jim/Momentum/aggregate/carrier"
+	"github.com/R-jim/Momentum/aggregate/knight"
+	"github.com/R-jim/Momentum/aggregate/spike"
+	"github.com/R-jim/Momentum/operator"
+	"github.com/R-jim/Momentum/util"
+)
+
 /*
 TODO:
-spike will patrol around the artifact in slow pace, next closest position to artifact
-if detect carrier/knight will switch to multiplier mode and move in to intercept
 attack carrier/knight when in range 1 from spike
 */
+
+type SpikeAutomaton interface {
+	Auto(id string) error
+}
+
+type spikeImpl struct {
+	carrierStore carrier.Store
+	knightStore  knight.Store
+	spikeStore   spike.Store
+
+	operator operator.Operator
+}
+
+func NewSpikeAutomaton(carrierStore carrier.Store, knightStore knight.Store, spikeStore spike.Store, operator operator.Operator) SpikeAutomaton {
+	return spikeImpl{
+		carrierStore: carrierStore,
+		knightStore:  knightStore,
+		spikeStore:   spikeStore,
+
+		operator: operator,
+	}
+}
+
+func (i spikeImpl) Auto(id string) error {
+	return i.AutoStrike(id)
+}
+
+func (i spikeImpl) AutoStrike(id string) error {
+	positionState, err := spike.GetPositionState(i.spikeStore, id)
+	if err != nil {
+		return err
+	}
+
+	targetKnightIDs := []string{}
+	targetCarrierIDs := []string{}
+
+	for _, knightID := range i.knightStore.GetEntityIDs() {
+		knightCombatState, err := knight.GetState(i.knightStore, knightID)
+		if err != nil {
+			return err
+		}
+		if knightCombatState.Health.Value <= 0 {
+			continue
+		}
+
+		knightPositionState, err := knight.GetPositionState(i.knightStore, knightID)
+		if err != nil {
+			return err
+		}
+		_, _, distance := util.GetDistances(positionState.X, positionState.Y, knightPositionState.X, knightPositionState.Y)
+		if distance <= 1 {
+			targetKnightIDs = append(targetKnightIDs, knightID)
+		}
+	}
+
+	for _, carrierID := range i.carrierStore.GetEntityIDs() {
+		carrierCombatState, err := carrier.GetCombatState(i.carrierStore, carrierID)
+		if err != nil {
+			return err
+		}
+		if carrierCombatState.Health.Value <= 0 {
+			continue
+		}
+
+		carrierPositionState, err := carrier.GetPositionState(i.carrierStore, carrierID)
+		if err != nil {
+			return err
+		}
+		_, _, distance := util.GetDistances(positionState.X, positionState.Y, carrierPositionState.X, carrierPositionState.Y)
+		if distance <= 1 {
+			targetCarrierIDs = append(targetCarrierIDs, carrierID)
+		}
+	}
+
+	for _, targetKnightID := range targetKnightIDs {
+		err = i.operator.Spike.Strike(id, targetKnightID)
+		if err != nil {
+			return err
+		}
+		//TODO: knight take damage
+	}
+	for _, targetCarrierID := range targetCarrierIDs {
+		err = i.operator.Spike.Strike(id, targetCarrierID)
+		if err != nil {
+			return err
+		}
+		//TODO: carrier take damage
+	}
+	return nil
+}

--- a/operator/spike.go
+++ b/operator/spike.go
@@ -32,3 +32,14 @@ func (j spikeOperator) Move(spikeID string, toPosition spike.PositionState) erro
 	j.animator.AppendEvent(spikeMoveEvent)
 	return nil
 }
+
+func (j spikeOperator) Strike(spikeID string, targetID string) error {
+	spikeStrikeEvent := spike.NewStrikeEvent(spikeID, targetID)
+	err := j.spikeAggregator.Aggregate(spikeStrikeEvent)
+	if err != nil {
+		return err
+	}
+
+	j.animator.AppendEvent(spikeStrikeEvent)
+	return nil
+}


### PR DESCRIPTION
Spike Automaton: 
- Get combat state of knights, carriers
- If knights, carrier's `HP's value > 0` and is within `1 pixel` distance, trigger spike's strike operator

Tickets:
- [Aggregate logic for spike](https://github.com/R-Jim/Momentum/issues/2)
- [Strike automaton for spike](https://github.com/R-Jim/Momentum/issues/8)