### PR TITLE
Fix knight, spike automaton for autoStrike

### DIFF
--- a/aggregate/knight/aggregator.go
+++ b/aggregate/knight/aggregator.go
@@ -74,6 +74,7 @@ func (i aggregateImpl) aggregate(event Event) error {
 			return common.ErrAggregateFail
 		}
 	case ChangeTargetEffect:
+	case DamageEffect:
 	default:
 		return common.ErrEffectNotSupported
 	}

--- a/aggregate/knight/state.go
+++ b/aggregate/knight/state.go
@@ -16,6 +16,7 @@ type TargetType string
 
 const (
 	WaitPointTargetType TargetType = "wait_point"
+	SpikeTargetType     TargetType = "spike"
 )
 
 type Target struct {

--- a/animator/knight.go
+++ b/animator/knight.go
@@ -52,6 +52,8 @@ func (ja KnightAnimator) animateEvent(screen *ebiten.Image, id string) error {
 		case knight.MoveEffect:
 			stateImage = flyingImage
 		case knight.ChangeTargetEffect:
+		case knight.DamageEffect:
+		case knight.StrikeEffect:
 		default:
 			return fmt.Errorf("[KnightAnimator][ERROR][%v] err: %v", event.Effect, ErrEffectNotSupported.Error())
 		}

--- a/animator/spike.go
+++ b/animator/spike.go
@@ -96,6 +96,11 @@ func (sa SpikeAnimator) animateState(screen *ebiten.Image, id string) error {
 		stateImage = normalImage
 	}
 
+	combatState, _ := spike.GetState(sa.store, id)
+	if combatState.Health.Value <= 0 {
+		return nil
+	}
+
 	if stateImage != nil {
 		op := &ebiten.DrawImageOptions{}
 		op.GeoM.Translate(positionState.X, positionState.Y)

--- a/automaton/knight.go
+++ b/automaton/knight.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/R-jim/Momentum/aggregate/knight"
 	"github.com/R-jim/Momentum/aggregate/spike"
+	"github.com/R-jim/Momentum/info"
 	"github.com/R-jim/Momentum/operator"
 	"github.com/R-jim/Momentum/util"
 )
@@ -46,7 +47,7 @@ func (i knightImpl) Auto(id string) error {
 }
 
 func (i knightImpl) autoPatrol(id string) error {
-	radius := float64(40)
+	radius := float64(1)
 
 	combatState, err := knight.GetState(i.knightStore, id)
 	if err != nil {
@@ -84,6 +85,14 @@ func (i knightImpl) autoPatrol(id string) error {
 }
 
 func (i knightImpl) autoStrike(id string) error {
+	combatState, err := knight.GetState(i.knightStore, id)
+	if err != nil {
+		return err
+	}
+	if combatState.Health.Value <= 0 {
+		return nil
+	}
+
 	positionState, err := knight.GetPositionState(i.knightStore, id)
 	if err != nil {
 		return err
@@ -105,7 +114,7 @@ func (i knightImpl) autoStrike(id string) error {
 			return err
 		}
 		_, _, distance := util.GetDistances(positionState.X, positionState.Y, spikePositionState.X, spikePositionState.Y)
-		if distance <= 1 {
+		if distance <= info.MELEE_RANGE {
 			targetSpikeIDs = append(targetSpikeIDs, spikeID)
 		}
 	}

--- a/automaton/spike.go
+++ b/automaton/spike.go
@@ -4,6 +4,7 @@ import (
 	"github.com/R-jim/Momentum/aggregate/carrier"
 	"github.com/R-jim/Momentum/aggregate/knight"
 	"github.com/R-jim/Momentum/aggregate/spike"
+	"github.com/R-jim/Momentum/info"
 	"github.com/R-jim/Momentum/operator"
 	"github.com/R-jim/Momentum/util"
 )
@@ -40,6 +41,14 @@ func (i spikeImpl) Auto(id string) error {
 }
 
 func (i spikeImpl) AutoStrike(id string) error {
+	combatState, err := spike.GetState(i.spikeStore, id)
+	if err != nil {
+		return err
+	}
+	if combatState.Health.Value <= 0 {
+		return nil
+	}
+
 	positionState, err := spike.GetPositionState(i.spikeStore, id)
 	if err != nil {
 		return err
@@ -62,7 +71,7 @@ func (i spikeImpl) AutoStrike(id string) error {
 			return err
 		}
 		_, _, distance := util.GetDistances(positionState.X, positionState.Y, knightPositionState.X, knightPositionState.Y)
-		if distance <= 1 {
+		if distance <= info.MELEE_RANGE {
 			targetKnightIDs = append(targetKnightIDs, knightID)
 		}
 	}

--- a/info/weapon.go
+++ b/info/weapon.go
@@ -1,0 +1,5 @@
+package info
+
+const (
+	MELEE_RANGE = 2
+)

--- a/operator/new.go
+++ b/operator/new.go
@@ -48,6 +48,7 @@ func New(aggregator OperatorAggregator, animator animator.Animator) Operator {
 		Spike: spikeOperator{
 			artifactAggregator: aggregator.ArtifactAggregator,
 			spikeAggregator:    aggregator.SpikeAggregator,
+			knightAggregator:   aggregator.KnightAggregator,
 			animator:           animator,
 		},
 		Artifact: artifactOperator{
@@ -57,6 +58,7 @@ func New(aggregator OperatorAggregator, animator animator.Animator) Operator {
 		},
 		Knight: knightOperator{
 			knightAggregator: aggregator.KnightAggregator,
+			spikeAggregator:  aggregator.SpikeAggregator,
 			animator:         animator,
 		},
 	}

--- a/scene/ui/main.go
+++ b/scene/ui/main.go
@@ -13,24 +13,16 @@ import (
 	"github.com/R-jim/Momentum/aggregate/spike"
 	"github.com/R-jim/Momentum/aggregate/storage"
 	"github.com/R-jim/Momentum/animator"
-	"github.com/R-jim/Momentum/automaton"
 	"github.com/R-jim/Momentum/operator"
 	"github.com/R-jim/Momentum/ui"
 	"github.com/hajimehoshi/ebiten/v2"
-	"github.com/hajimehoshi/ebiten/v2/inpututil"
 	"golang.org/x/sync/errgroup"
 )
 
 var (
-	opt        operator.Operator
-	ani        animator.Animator
-	knightAuto automaton.KnightAutomaton
-	spikeAuto  automaton.SpikeAutomaton
-
+	opt      operator.Operator
+	ani      animator.Animator
 	knightID string
-	spikeID  string
-
-	isPaused bool
 )
 
 // for testing
@@ -43,33 +35,8 @@ func initEntities() {
 	}
 
 	err = opt.Knight.Move(knightID, knight.PositionState{
-		X: 150,
-		Y: 100,
-	})
-	if err != nil {
-		fmt.Printf("[ERROR]initEntities: %v\n", err.Error())
-	}
-
-	spikeID = "spike_1"
-	err = opt.Spike.Init(spikeID, "")
-	if err != nil {
-		fmt.Printf("[ERROR]initEntities: %v\n", err.Error())
-	}
-
-	err = opt.Spike.Move(spikeID, spike.PositionState{
 		X: 100,
 		Y: 100,
-	})
-	if err != nil {
-		fmt.Printf("[ERROR]initEntities: %v\n", err.Error())
-	}
-
-	err = opt.Knight.ChangeTarget(knightID, knight.Target{
-		ID: spikeID,
-		Position: knight.PositionState{
-			X: 100,
-			Y: 100,
-		},
 	})
 	if err != nil {
 		fmt.Printf("[ERROR]initEntities: %v\n", err.Error())
@@ -110,33 +77,13 @@ func init() {
 		ani,
 	)
 
-	knightAuto = automaton.NewKnightAutomaton(knightStore, spikeStore, opt)
-	spikeAuto = automaton.NewSpikeAutomaton(carrierStore, knightStore, spikeStore, opt)
 	initEntities()
-
-	isPaused = true
 }
 
 type Game struct {
 }
 
 func (g *Game) Update() error {
-	if inpututil.IsKeyJustPressed(ebiten.KeyP) {
-		isPaused = false
-	}
-	if isPaused {
-		return nil
-	}
-	err := knightAuto.Auto(knightID)
-	if err != nil {
-		return err
-	}
-	err = spikeAuto.Auto(spikeID)
-	if err != nil {
-		return err
-	}
-
-	isPaused = true
 	// operations := []func() error{}
 	// operations = append(operations, userInput()...)
 	// go runConcurrently(operations)
@@ -179,7 +126,7 @@ func (g *Game) Layout(outsideWidth, outsideHeight int) (screenWidth, screenHeigh
 }
 
 func main() {
-	ebiten.SetWindowSize(800, 600)
+	ebiten.SetWindowSize(1000, 800)
 	ebiten.SetWindowTitle("Momentum")
 
 	game := &Game{}


### PR DESCRIPTION
Aggregates:
- Add case for knight's `DamageEffect`
- Add knight's `SpikeTargetType`

Animator:
- Add missing effect animation cases

Automaton:
- Add health check before autoStrike
- Adjust melee range

Tickets:
- https://github.com/R-Jim/Momentum/issues/8
- https://github.com/R-Jim/Momentum/issues/15