### PR TITLE
Add street entity enter aggregate

### DIFF
--- a/aggregate/event/street.go
+++ b/aggregate/event/street.go
@@ -1,3 +1,19 @@
 package event
 
-const ()
+import (
+	"github.com/google/uuid"
+)
+
+const (
+	StreetEntityEnterEffect Effect = "STREET_ENTITY_ENTER"
+)
+
+func NewStreetEntityEnterEvent(streetID uuid.UUID, version int, entityID uuid.UUID) Event {
+	return Event{
+		ID:       uuid.New(),
+		EntityID: streetID,
+		Version:  version,
+		Effect:   StreetEntityEnterEffect,
+		Data:     entityID,
+	}
+}


### PR DESCRIPTION
**Descriptions**
-  Update street state, add `EntityMap map[uuid.UUID]bool`
-  Add `STREET_ENTITY_ENTER` Effect, new `NewStreetEntityEnterEvent`event function
-  Add `STREET_ENTITY_ENTER` state render
-  Add `STREET_ENTITY_ENTER` aggregate

**Tickets**
- [Street Enter Aggregate](https://github.com/users/R-Jim/projects/3/views/1#)