### PR TITLE
Update Mio automaton EnterStreetFromCurrentPosition to enter/leave street

### DIFF
--- a/aggregate/aggregator/aggregator.go
+++ b/aggregate/aggregator/aggregator.go
@@ -26,9 +26,9 @@ func (i aggregateImpl) GetStore() *store.Store {
 
 func (i aggregateImpl) Aggregate(event event.Event) error {
 	if err := aggregate(i.store, i.aggregateSet, event); err != nil {
-		return fmt.Errorf("[%s][%v] %v", i.name, event.Effect, err)
+		return fmt.Errorf("[%s][%v][%v] %v.\n", i.name, event.EntityID, event.Effect, err)
 	}
-	fmt.Printf("[%s][%v] aggregated.\n", i.name, event.Effect)
+	fmt.Printf("[%s][%v][%v] aggregated.\n", i.name, event.EntityID, event.Effect)
 	return nil
 }
 

--- a/aggregate/aggregator/street.go
+++ b/aggregate/aggregator/street.go
@@ -90,8 +90,11 @@ func GetStreetState(events []event.Event) (StreetState, error) {
 			if err != nil {
 				return state, err
 			}
+
+			state.ID = e.EntityID
 			state.HeadA = heads[0]
 			state.HeadB = heads[1]
+			state.EntityMap = map[uuid.UUID]bool{}
 
 		case event.StreetEntityEnterEffect:
 			entityID, err := event.ParseData[uuid.UUID](e)

--- a/aggregate/event/mio.go
+++ b/aggregate/event/mio.go
@@ -19,7 +19,7 @@ func NewMioInitEvent(entityID uuid.UUID, position math.Pos) Event {
 	return Event{
 		ID:       uuid.New(),
 		EntityID: entityID,
-		Version:  0,
+		Version:  1,
 		Effect:   MioInitEffect,
 		Data:     position,
 	}

--- a/aggregate/event/street.go
+++ b/aggregate/event/street.go
@@ -16,6 +16,7 @@ func NewStreetInitEvent(streetID uuid.UUID, headA, headB math.Pos) Event {
 	return Event{
 		ID:       uuid.New(),
 		EntityID: streetID,
+		Version:  1,
 		Effect:   StreetInitEffect,
 		Data:     []math.Pos{headA, headB},
 	}


### PR DESCRIPTION
**Descriptions**
Update Mio's `automaton`'s `EnterStreetFromCurrentPosition` to include enter/leave street. This instead of creating Street's `automaton` for checking is due to performance(1 Mio vs many Streets).

**Tickets**
- [Mio enter street#50](https://github.com/R-Jim/Momentum/issues/50)

**Changes**
- Fix Street's state compose for `Init` event
- Add Street's operator `EntityEnter`, `EntityLeave`
- Update Mio's `automaton`'s `EnterStreetFromCurrentPosition` to include enter/leave street.
- Minor update to aggregate logging