### PR TITLE
feat: add Mio path finding automaton

### DIFF
--- a/automaton/mio.go
+++ b/automaton/mio.go
@@ -2,6 +2,7 @@ package automaton
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/R-jim/Momentum/aggregate/aggregator"
 	"github.com/R-jim/Momentum/aggregate/event"
@@ -14,12 +15,23 @@ import (
 type mioAutomaton struct {
 	entityID uuid.UUID
 
+	mapPaths []math.Path
+	mapGraph math.Graph
+
 	mioStore      *store.Store
 	streetStore   *store.Store
 	buildingStore *store.Store
 
 	mioOperator    operator.MioOperator
 	streetOperator operator.StreetOperator
+
+	// For performance optimization
+	prevSelectedBuilding uuid.UUID
+}
+
+type shortestPath struct {
+	poses []math.Pos
+	cost  int
 }
 
 func (m mioAutomaton) Automate() {
@@ -63,7 +75,7 @@ func (m mioAutomaton) EnterStreetFromCurrentPosition() {
 	}
 }
 
-func (m mioAutomaton) MioMoodBehavior() {
+func (m *mioAutomaton) MioMoodBehavior() {
 	events := (*m.mioStore).GetEvents()[m.entityID]
 	mioActivityState, err := aggregator.GetMioActivityState(events)
 	if err != nil {
@@ -109,10 +121,147 @@ func (m mioAutomaton) MioMoodBehavior() {
 		return
 	}
 
+	if m.prevSelectedBuilding == selectedBuildingID {
+		return
+	}
+
+	m.prevSelectedBuilding = selectedBuildingID
+
 	err = m.mioOperator.SelectBuilding(mioState.ID, selectedBuildingID)
 	if err != nil {
 		fmt.Print(err)
 	}
+
+	m.mioBuildingPathFinding()
+}
+
+func (m mioAutomaton) mioBuildingPathFinding() {
+	if m.prevSelectedBuilding.String() == uuid.Nil.String() {
+		return
+	}
+
+	var plannedPath []math.Pos
+
+	var mioPos, streetHeadAPos, streetHeadBPos, buildingPos math.Pos
+
+	{
+		buildingEvents := (*m.buildingStore).GetEvents()[m.prevSelectedBuilding]
+		buildingState, err := aggregator.GetBuildingState(buildingEvents)
+		if err != nil {
+			fmt.Print(err)
+		}
+
+		events := (*m.mioStore).GetEvents()[m.entityID]
+		mioState, err := aggregator.GetMioState(events)
+		if err != nil {
+			fmt.Print(err)
+		}
+
+		streetEvents := (*m.streetStore).GetEvents()[mioState.StreetID]
+		streetState, err := aggregator.GetStreetState(streetEvents)
+		if err != nil {
+			fmt.Print(err)
+		}
+
+		mioPos = mioState.Position
+		streetHeadAPos = streetState.HeadA
+		streetHeadBPos = streetState.HeadB
+		buildingPos = buildingState.Pos
+	}
+
+	streetPathCost := 0
+	for _, path := range m.mapPaths {
+		if (path.Start == streetHeadAPos && path.End == streetHeadBPos) || (path.Start == streetHeadBPos && path.End == streetHeadAPos) {
+			streetPathCost = path.Cost
+		}
+	}
+
+	_, _, distFromA := math.GetDistances(mioPos, streetHeadAPos)
+	_, _, distFromB := math.GetDistances(mioPos, streetHeadBPos)
+	totalDist := distFromA + distFromB
+
+	var shortestPathFromStreetA, shortestPathFromStreetB shortestPath
+	{
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			shortestPathFromStreetA = findShortestPath(m.mapGraph, m.mapPaths, streetHeadAPos, buildingPos)
+		}()
+		go func() {
+			defer wg.Done()
+			shortestPathFromStreetB = findShortestPath(m.mapGraph, m.mapPaths, streetHeadBPos, buildingPos)
+		}()
+
+		wg.Wait()
+	}
+
+	{
+		shortestPathFromStreetACost := float64(streetPathCost)*distFromA/totalDist + float64(shortestPathFromStreetA.cost)
+		shortestPathFromStreetBCost := float64(streetPathCost)*distFromB/totalDist + float64(shortestPathFromStreetB.cost)
+		if shortestPathFromStreetACost <= shortestPathFromStreetBCost {
+			plannedPath = append([]math.Pos{streetHeadAPos}, shortestPathFromStreetA.poses...)
+		} else {
+			plannedPath = append([]math.Pos{streetHeadBPos}, shortestPathFromStreetB.poses...)
+		}
+	}
+
+	err := m.mioOperator.ChangePlannedPoses(m.entityID, plannedPath)
+	if err != nil {
+		fmt.Print(err)
+	}
+}
+
+func findShortestPath(mapGraph math.Graph, mapPaths []math.Path, start, end math.Pos) shortestPath {
+	var sp *shortestPath
+
+	paths := mapGraph.FindPath(start, end)
+
+	var wg sync.WaitGroup
+	wg.Add(len(paths))
+	for _, path := range paths {
+		p := path
+		go func() {
+			defer wg.Done()
+
+			lastPos := start
+			cost := 0
+
+			for _, pos := range p {
+				if sp != nil && cost > sp.cost {
+					return
+				}
+
+				for _, mp := range mapPaths {
+					if (mp.Start == lastPos && mp.End == pos) || (mp.Start == pos && mp.End == lastPos) {
+						cost += mp.Cost
+						break
+					}
+				}
+
+				lastPos = pos
+			}
+
+			if sp != nil && cost > sp.cost {
+				return
+			}
+
+			if sp == nil {
+				sp = &shortestPath{}
+			}
+
+			sp.poses = p
+			sp.cost = cost
+		}()
+	}
+	wg.Wait()
+
+	if sp == nil {
+		return shortestPath{}
+	}
+
+	return *sp
 }
 
 func isBuildingFitMood(buildingState aggregator.BuildingState, isBored, isHungry, isThirsty bool) bool {


### PR DESCRIPTION
**Description**
Add Mio path-finding automaton
- From the current Mio's street, start from `HeadA`, `HeadB` of the street, and calculate the paths based on `cost`
- The connector from a building to a street also counts as a street with `HeadA`/`HeadB` is a point of the street and the building's `position`

**Tickets**
- https://github.com/R-Jim/Momentum/issues/68